### PR TITLE
Create a markdown manual for research assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,54 @@
-# Overview
+# Empirical Economics Lab Manual
 
-This repository contains the lab manual (and associated source code) for the [Contextual Dynamics Laboratory (CDL)](http://www.context-lab.com) at [Dartmouth College](https://www.dartmouth.edu).  The lab manual describes the rights and responsibilities of all CDL members, and it introduces our general research approach and lab policies.
+Welcome to the Empirical Economics Lab Manual! This repository is a living handbook for research assistants (RAs) working in computational and empirical social science. It distills best practices for reproducible research, coding standards across multiple languages, and workflow organization so that every project can be replicated and extended with confidence.
 
-All new lab members are required to read (and modify!) this repository *prior* to joining the lab.  New lab members are also required to complete a list of basic tasks (and signify that they have done so via a checklist at the end of the manual).  The tasks are intended to ensure that every lab member is on the same page with respect to expectations and that every lab member has acquired a minimum viable set of skills needed to do research in the lab.
+---
 
-A PDF of the latest version of the lab manual may always be found [here](https://github.com/ContextLab/lab-manual/blob/master/lab_manual.pdf).
+## 📚 Table of Contents
 
-# Why are we sharing this repository with the public?
-Our lab manual is, in one sense, intended to provide information that is specific to the CDL.  So it's possible it'll be useful only to CDL lab members.  However, we hope that others might find some aspects of the manual useful.  For example, perhaps you like the look of the [LaTeX template](https://ctan.org/pkg/tufte-latex?lang=en) we used.  Or perhaps you like some of the contents and want to incorporate something like it into your own operating manual.  Or maybe you *don't* like something, and you want to use our manual as a counterexample!  Whatever you'd like to do with the contents, we offer this repository freely and in the spirit of openness and collaboration.  By the same token, we make no claims as to the accuracy of the documentation or code herein, so we invite you to proceed at your own risk.
+1. [Fundamentals](fundamentals/README.md) – Core principles of reproducible research applicable to any language or project.
+2. [Language-Specific Guides](languages/README.md)
+   - [Stata Guide](languages/stata.md)
+   - [R Guide](languages/r.md)
+   - [Python Guide](languages/python.md)
+   - [Shell Scripting Guide](languages/shell.md)
+3. [Workflows](workflows/README.md) – Project organization patterns, dependency management, and automation.
+4. [Templates](templates/README.md) – Ready-to-use code templates you can copy into your own projects.
+5. [Examples](examples/) – Minimal example projects that demonstrate the practices in action.
+6. [Best Practices Checklist](best_practices_checklist.md) – Quick reference before you start, run, share, or publish research.
 
-# Contributing
-The way we  develop collaborative documents and code in the CDL is to have a central repository for each project (e.g. [this page](https://github.com/ContextLab/lab-manual)) that everyone on the project has read access to.  This repository is public, so everyone with an Internet connection has access to the contents of this repository, and anyone can (in principle) submit a pull request to change the contents.  In practice, however, any substantial (e.g. beyond simple typo and grammar corrections) changes will need to be discussed by CDL lab members in person (e.g. during our weekly lab meetings).  (So: feel free to contribute whatever you'd like, but before taking the time to do so please recognize that if you are not affiliated with the CDL, or planning to become affiliated, then it's unlikely that we'd incorporate major changes into the manual without having discussed it with you first.)
+---
 
-In order to modify the central code repository, you need to fork this repository, add your content to your fork, and then submit a pull request to incorporate your changes (from your fork) into the central repository.  This allows us to maintain a stable working version in the central repository that everyone can access and rely on, while also allowing individual contributors to maintain (unstable) working versions.  If these terms (forking, pulling, pushing, etc.) are unfamiliar or confusing, you should read through [these Git Tutorials](https://try.github.io/) before proceeding.
+## 🚀 Quick Start
 
-To set up your fork:
-1. Press the "fork" button in the upper right corner of the repository's website (link above).
-2. Clone your fork to your local machine (`git clone https://github.com/<GitHub Username>/lab-manual.git`).
-3. Set the central repository as an upstream remote: `git remote add upstream https://github.com/ContextLab/lab-manual.git`.
-4. Each time you want to make changes to your local copy, sync it with the central repository by running `git pull upstream master`.
-5. When you're done making changes, type `git commit -a -m "<MESSAGE DESCRIBING WHAT YOU CHANGED>` and then `git push`.
-6. Repeat steps 4 and 5 until you have something to share with the world.  Note: you can push broken code to your local fork without damaging anything in the central repository, so we encourage frequent committing and pushing (even of broken code) to your local fork.  This will ensure that (a) you always have a recent online backup of your work and (b) there is a clear record of what you did and the path you took to accomplish it.
-7. When you're ready to share your code with the world, go back to your fork's web page (`https://github.com/<GitHub Username>/lab-manual`), navigate to the "pull requests" tab (upper left), and press the "New pull request" button in the upper right.  Describe what you did and submit your pull request by filling out the prompts.  Then someone from the CDL will review the changes and merge them in, and everyone will have access to your changes.
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/<your-org>/empirical-econ-lab-manual.git
+   cd empirical-econ-lab-manual
+   ```
+2. Browse the **Fundamentals** to understand reproducible research foundations.
+3. Dive into the language guide that matches your stack.
+4. Copy a template from `/templates/` to bootstrap your analysis.
+5. Use the checklists to make sure your work is reproducible before sharing.
+
+---
+
+## 🤝 Contributing
+
+We welcome improvements! If you spot an issue or have an enhancement:
+
+1. **Fork** the repository and create a feature branch.
+2. Commit using [conventional](https://www.conventionalcommits.org/) present-tense messages (e.g., `Add Stata logging example`).
+3. Open a Pull Request describing your change.
+
+See the [GitHub Essentials guide](workflows/README.md#github-essentials-for-social-scientists) for more.
+
+---
+
+## 📄 License
+
+Distributed under the MIT License. See [LICENSE](LICENSE) for details.
+
+---
+
+> *Maintained with ♥ by the Empirical Economics Lab.*

--- a/best_practices_checklist.md
+++ b/best_practices_checklist.md
@@ -1,0 +1,38 @@
+# Best Practices Checklist ✅
+
+Use this checklist **before starting**, **before running analysis**, **before sharing code**, and **before publication**.
+
+---
+
+## 🟢 Before Starting a Project
+
+- [ ] Read the [Fundamentals](fundamentals/README.md).
+- [ ] Create a clean repository with `.gitignore`.
+- [ ] Sketch project directory tree.
+- [ ] Gather raw data and store in `data/input/`.
+
+## 🟡 Before Running Analysis
+
+- [ ] Activate virtualenv / renv / set Stata paths.
+- [ ] Ensure raw data untouched; create copies if needed.
+- [ ] Run unit tests (`pytest`, `testthat`, `stataunit`).
+- [ ] Confirm scripts have headers and inline comments.
+
+## 🟠 Before Sharing Code
+
+- [ ] Run formatter/linter (Black, styler, ado-lint).
+- [ ] Clean logs and remove large derived files from Git.
+- [ ] Update `README.md` with run instructions.
+- [ ] Push branch and open Pull Request with clear message.
+
+## 🔴 Before Publication
+
+- [ ] Regenerate **all** results from scratch on fresh machine.
+- [ ] Verify checksums of replication package.
+- [ ] Double-check variable definitions against codebook.
+- [ ] Archive replication package on Zenodo/OSF with DOI.
+- [ ] Add citation for replication package in manuscript.
+
+---
+
+Pro tip: Automate these steps with CI/CD pipelines and badge your repository with build status and test coverage.

--- a/fundamentals/README.md
+++ b/fundamentals/README.md
@@ -1,0 +1,112 @@
+# Fundamentals of Reproducible Research
+
+This section covers the language-agnostic principles that underpin every successful empirical economics project. Master these fundamentals before diving into any language-specific guide.
+
+---
+
+## 1️⃣ Principles of Reproducible Research
+
+1. **Transparency** – Make every step of your analysis visible.
+2. **Automation** – Replace manual steps with scripts and pipelines.
+3. **Version Control** – Track changes in code *and* data.
+4. **Documentation** – Explain *what* you did, *why*, and *how* to rerun it.
+5. **Portability** – Ensure others can reproduce results on another machine.
+
+> "An article about computational science is not the scholarship itself, it is merely *advertising* of the scholarship." – D. Donoho (1998)
+
+---
+
+## 2️⃣ Universal Coding Best Practices
+
+| Principle | Description |
+|-----------|-------------|
+| DRY (Don't Repeat Yourself) | Factor out repeated logic into functions or programs. |
+| Meaningful Names | Use descriptive variable, function, and file names (`clean_data.py` > `cd.py`). |
+| Small Commits | Save work frequently with focused, atomic commits. |
+| Lint Early & Often | Use language-specific linters/formatters (Black for Python, *ado-lint* for Stata, *styler* for R). |
+| Defensive Programming | Check assumptions, validate inputs, and fail loudly. |
+
+---
+
+## 3️⃣ Recommended Project Directory Structure
+
+```text
+project/
+├── code/
+│   ├── 0_data_prep/
+│   ├── 1_analysis/
+│   └── 2_output/
+├── data/
+│   ├── input/
+│   ├── intermediate_datasets/
+│   └── output/
+├── output/
+│   ├── figures/
+│   ├── tables/
+│   └── logs/
+├── docs/
+└── internal/
+```
+
+**Why this structure?**
+
+* Separate raw `data/input` from processed `data/output` to protect originals.
+* Keep all scripts in `code/`, ordered with numeric prefixes so execution order is obvious.
+* Store generated artefacts in `output/` so you can add it to `.gitignore` if files are large.
+* Place manuscripts, memos, or slide decks in `docs/`.
+* Use `internal/` for proprietary or confidential material that never goes to version control.
+
+---
+
+## 4️⃣ Data Management Principles
+
+1. **Immutable Raw Data** – Never overwrite the original dataset. Copy it into `data/input/`.
+2. **Single Source of Truth** – Keep only one processed version of each dataset.
+3. **Document Transformations** – Record every cleaning, merge, or reshape step in code.
+4. **Data Dictionaries** – Maintain variable definitions and units in `docs/codebook.md`.
+
+---
+
+## 5️⃣ Version Control Concepts
+
+- **Repository** – A collection of tracked files.
+- **Commit** – A snapshot of the repository at a point in time.
+- **Branch** – A parallel line of development (use feature branches!).
+- **Pull Request** – A proposal to merge changes into another branch.
+
+> Use `git add -p` to stage *only* the lines that belong to the current logical change.
+
+---
+
+## 6️⃣ Documentation Standards
+
+### Script Headers (minimum template)
+
+```text
+# ==============================================================================
+# PURPOSE:        One-sentence summary of what the script does
+# AUTHOR:         Your Name <you@uni.edu>
+# CREATED:        2024-05-15
+# LAST UPDATED:   2024-05-15
+# INPUTS:         ../data/input/raw_survey.csv
+# OUTPUTS:        ../data/output/clean_survey.csv
+# NOTES:          Any caveats or dependencies
+# ==============================================================================
+```
+
+### Inline Comments
+
+- Explain *why*, not just *what* (code shows *what*).
+- Use comments to cite papers or methods.
+
+### README Files
+
+Each major directory **must** contain a `README.md` with:
+
+1. Purpose of the directory.
+2. How to reproduce its contents.
+3. Key files and their roles.
+
+---
+
+☑️ *Continue to the [Language-Specific Guides](../languages/README.md) once you are comfortable with these fundamentals.*

--- a/languages/README.md
+++ b/languages/README.md
@@ -1,0 +1,14 @@
+# Language-Specific Guides
+
+Choose the guide that matches your primary analysis language. Each guide applies the general fundamentals to concrete tooling, naming conventions, and best practices.
+
+| Language | Guide |
+|----------|-------|
+| Stata | [Stata Guide](stata.md) |
+| R | [R Guide](r.md) |
+| Python | [Python Guide](python.md) |
+| Shell | [Shell Scripting Guide](shell.md) |
+
+---
+
+If you switch languages within a project, ensure that **all** scripts follow the same directory and documentation standards described in the [Fundamentals](../fundamentals/README.md).

--- a/languages/python.md
+++ b/languages/python.md
@@ -1,0 +1,123 @@
+# Python Guide
+
+This guide follows [PEP 8](https://peps.python.org/pep-0008/) conventions and uses the **Black** formatter for consistent style.
+
+---
+
+## ⚙️ Environment Setup
+
+1. **Create a virtual environment**
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+2. **Install dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. **Format automatically**
+   ```bash
+   pip install black
+   black .
+   ```
+
+Add `venv/` and `.mypy_cache/` to `.gitignore`.
+
+---
+
+## ✍️ Naming & Style Highlights
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Variables & Functions | snake_case | `clean_data`, `run_regression` |
+| Classes | PascalCase | `OLSModel` |
+| Constants | UPPER_SNAKE_CASE | `MAX_ITERATIONS` |
+| Docstrings | Triple quotes with [Google style](https://google.github.io/styleguide/pyguide.html#s3.8.3-comments-and-docstrings) | `"""Calculate Gini coefficient."""` |
+| Type Hints | Use `typing` module | `def load_data(path: str) -> pd.DataFrame:` |
+
+---
+
+## 📝 File Header Template
+
+```python
+"""Short description (one sentence).
+
+Author: Your Name <you@uni.edu>
+Created: 2024-05-15
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+```
+
+---
+
+## 🔑 Best Practices for Data Analysis
+
+1. **Use `pathlib.Path`** – Avoid hard-coding OS-specific paths.
+2. **Cache Intermediate Data** – Save cleaned datasets as `parquet` to speed up reruns.
+3. **Prefer `pandas` Pipelines** – Chain operations with `assign` and `pipe`.
+4. **Separate I/O & Logic** – Keep data loading functions separate from analysis logic.
+5. **Logging** – Configure `logging` at `INFO` level in scripts; write to `output/logs/`.
+6. **Unit Tests** – Place tests in `tests/` and run with `pytest`.
+
+---
+
+## 🏗️ Example Function with Type Hints & Docstring
+
+```python
+from pathlib import Path
+import pandas as pd
+
+
+def load_clean_data(path: Path) -> pd.DataFrame:
+    """Load raw CSV, clean column names, and return a DataFrame.
+
+    Args:
+        path: Path to raw data CSV.
+
+    Returns:
+        Cleaned pandas DataFrame.
+    """
+    df = (
+        pd.read_csv(path)
+        .rename(columns=str.lower)
+        .dropna(subset=["income", "wage"])
+    )
+    return df
+```
+
+---
+
+## 🔍 Sample `pytest` Test
+
+```python
+import pandas as pd
+from pathlib import Path
+from your_project.cleaning import load_clean_data
+
+
+def test_load_clean_data(tmp_path: Path):
+    # Create a dummy CSV
+    data = """income,wage\n1000,20\n2000,40"""
+    test_file = tmp_path / "dummy.csv"
+    test_file.write_text(data)
+
+    df = load_clean_data(test_file)
+
+    assert (df["income"] > 0).all()
+    assert df.shape[0] == 2
+```
+
+Run all tests:
+```bash
+pytest -q
+```
+
+---
+
+## 📚 Further Reading
+
+- [Effective Pandas](https://github.com/TomAugspurger/effective-pandas)
+- [Black formatter](https://black.readthedocs.io/en/stable/)

--- a/languages/r.md
+++ b/languages/r.md
@@ -1,0 +1,101 @@
+# R Guide
+
+This guide applies [Google's R Style Guide](https://google.github.io/styleguide/Rguide.html) to empirical economics projects.
+
+---
+
+## 📂 Recommended Project Layout (RStudio)
+
+```text
+project/
+├── project.Rproj        <- RStudio project file
+├── renv.lock            <- Dependency lockfile (optional)
+└── code/
+    ├── 0_setup.R        <- Load libraries, define paths
+    ├── 1_clean_data.R   <- Data wrangling with tidyverse
+    ├── 2_analysis.R     <- Estimation & models
+    ├── 3_figures.R      <- Visualization via ggplot2
+    └── 4_tables.R       <- Export regression tables
+```
+
+---
+
+## ✍️ Naming Conventions
+
+| Item | Convention | Example |
+|------|------------|---------|
+| Variables | snake_case | `tax_long`, `gg_kdb` |
+| Functions | verb_noun | `save_plot()`, `clean_directory()` |
+| Scripts | numeric prefixes | `02_merge_trade.R` |
+| Packages | explicit at top | `library(tidyverse)` |
+
+---
+
+## 📝 Script Header Template
+
+```r
+## =============================================================================
+# PURPOSE:   [Clear description]
+# INPUTS:    [List inputs]
+# OUTPUTS:   [List outputs]
+# AUTHOR:    Your Name <you@uni.edu>
+# CREATED:   2024-05-15
+## =============================================================================
+```
+
+---
+
+## 🔑 Best Practices
+
+1. **Tidyverse First** – Use `dplyr`, `tidyr`, `purrr` for data manipulation.
+2. **Explicit Libraries** – Load packages at the top of every script.
+3. **Functional Programming** – Wrap repeated tasks in functions and, where possible, map over lists.
+4. **Use `here()`** – Build file paths relative to project root for portability.
+5. **Consistent Plot Themes** – Set a global theme with `theme_set()`.
+6. **Unit Tests** – Place tests in `tests/` and use `testthat::test_that()`.
+
+---
+
+## ⚙️ Example: Cleaning Data with Tidyverse
+
+```r
+library(tidyverse)
+
+clean_employment <- function(raw_path, out_path) {
+  read_csv(raw_path) %>%
+    janitor::clean_names() %>%
+    filter(year >= 2000) %>%
+    mutate(real_wage = wage / cpi) %>%
+    write_csv(out_path)
+}
+
+clean_employment("../data/input/employment.csv",
+                "../data/output/employment_clean.csv")
+```
+
+---
+
+## 🔍 Testing Example
+
+```r
+# tests/test-clean.R
+library(testthat)
+source("../code/1_clean_data.R")
+
+test_that("real wage is positive", {
+  df <- read_csv("../data/output/employment_clean.csv")
+  expect_true(all(df$real_wage > 0))
+})
+```
+
+Run all tests via:
+```r
+testthat::test_dir("tests")
+```
+
+---
+
+## 📚 Further Reading
+
+- [R for Data Science](https://r4ds.hadley.nz/)
+- [The tidyverse style guide](https://style.tidyverse.org/)

--- a/languages/shell.md
+++ b/languages/shell.md
@@ -1,0 +1,72 @@
+# Shell Scripting Guide (Bash)
+
+Robust shell scripts are invaluable for orchestrating workflows and creating replication packages.
+
+---
+
+## 🏗️ Script Structure
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+LOG_FILE="../output/logs/$(basename "$0" .sh)_$(date +%Y%m%d).log"
+
+log() {
+    local message="$1"
+    local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "[$timestamp] $message" | tee -a "$LOG_FILE"
+}
+
+main() {
+    log "Starting replication pipeline."
+    # ... your commands here ...
+    log "Finished!"
+}
+
+main "$@"
+```
+
+### Key Points
+
+1. **`set -euo pipefail`** – Exit on error, undefined variable, or failed pipe.
+2. **Logging Function** – Timestamped logs written to file and stdout.
+3. **Main Function** – Encapsulate logic; call `main "$@"` at bottom.
+
+---
+
+## 🔒 Error Handling & Validation
+
+- Check prerequisites:
+  ```bash
+  command -v stata >/dev/null || { echo "Stata not found"; exit 1; }
+  ```
+- Validate inputs:
+  ```bash
+  [[ -f "$1" ]] || { echo "Input file missing"; exit 1; }
+  ```
+
+---
+
+## 🗂️ File Operations & Cleanup
+
+```bash
+# Create directory if it doesn't exist
+mkdir -p ../output/archives
+
+# Remove temporary files older than 30 days
+find ../output/tmp -type f -mtime +30 -delete
+```
+
+---
+
+## 📦 Cross-Platform Tips
+
+- Use `/usr/bin/env bash` shebang for portability.
+- Prefer `$(...)` over backticks for command substitution.
+- Avoid `sed -i` without extension on macOS; use `sed -i ''`.
+
+---
+
+☑️ See an end-to-end shell template in [Templates → Shell Replication Package](../templates/shell_replication_template.md).

--- a/languages/stata.md
+++ b/languages/stata.md
@@ -1,0 +1,100 @@
+# Stata Guide
+
+A concise yet comprehensive reference for writing clean, reproducible Stata code in empirical economics projects.
+
+---
+
+## 📂 Project Organization
+
+```text
+project/
+└── code/
+    ├── 0_setup.do        <- Install packages, set globals/paths
+    ├── 1_clean_data.do   <- Transform raw data
+    ├── 2_analysis.do     <- Run estimations & save results
+    ├── 3_output.do       <- Export tables & figures
+    └── master.do         <- Calls the scripts above in order
+```
+
+`master.do` should be the *only* script that a new RA needs to run to reproduce results.
+
+---
+
+## ✍️ Naming Conventions
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Variables | lowercase with underscores | `l_grossoutput` |
+| Programs  | descriptive verbs | `prep_data`, `export_reg_results` |
+| Tempfiles | use `tempfile` & meaningful names | `tempfile merged` |
+| Scripts   | numeric prefixes for execution order | `02_merge_trade.do` |
+
+---
+
+## 📝 Documentation Style
+
+```stata
+*------------------------------------------------------------------------------*
+* What this does:
+*   [Clear description of purpose]
+*
+* Dependencies:
+*   - [List required packages]
+*
+* Inputs:
+*   - [List input files with paths]
+*
+* Outputs:
+*   - [List output files with descriptions]
+*------------------------------------------------------------------------------*
+```
+
+Place this block **at the top** of every `.do` file.
+
+---
+
+## 🔑 Best Practices
+
+1. **Clean Slate** – Start scripts with:
+   ```stata
+   capture log close _all
+   clear all
+   set more off
+   ````
+2. **Drop Before Define** – Always `capture program drop myprog` before creating a program.
+3. **Centralize Paths** – Define globals for data and output paths *once* in `0_setup.do`.
+4. **Use Locals** – Store constants (e.g., lists of variables) in local macros.
+5. **Validate Data** – After merges, run `assert _merge == 3` and summarize key variables.
+6. **Log Everything** – Wrap scripts in `log using "../output/logs/1_clean_data.log", replace`.
+
+---
+
+## ⚙️ Example `master.do`
+
+```stata
+/*******************************************************************
+ Master script to reproduce the paper "Trade Shocks & Wages".
+ Place this file at project root and execute: do master.do
+*******************************************************************/
+
+// 1. Setup -------------------------------------------------------------------
+do "code/0_setup.do"
+
+// 2. Data Preparation ---------------------------------------------------------
+do "code/1_clean_data.do"
+
+// 3. Analysis -----------------------------------------------------------------
+do "code/2_analysis.do"
+
+// 4. Output -------------------------------------------------------------------
+do "code/3_output.do"
+
+// End -------------------------------------------------------------------------
+```
+
+---
+
+## 📚 Additional Resources
+
+- [Stata Style Guide: World Bank](https://github.com/worldbank/Stata-Style-Guide)
+- [Ado-lint](https://github.com/wbuchanan/ado-lint) – Linter for Stata code.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,9 @@
+# Templates Index
+
+Copy these templates into your project and customize as needed.
+
+| Template | Description |
+|----------|-------------|
+| [Shell Replication Package](shell_replication_template.md) | Bash script that generates a portable replication archive with logging and checksums. |
+| [Stata Analysis](stata_analysis_template.md) | Framework for modular Stata programs that produce ready-to-publish outputs. |
+| [R Visualization](r_visualization_template.md) | Consistent ggplot2 workflow for multi-panel figures with metadata. |

--- a/templates/r_visualization_template.md
+++ b/templates/r_visualization_template.md
@@ -1,0 +1,82 @@
+# R Visualization Template
+
+Produce publication-quality figures with a standardized look and reproducible pipeline.
+
+---
+
+## Setup
+
+```r
+# 0_setup_plots.R
+library(tidyverse)
+library(ggthemes)
+
+# Global theme
+theme_set(theme_bw(base_size = 12))
+
+default_colors <- c("#1b9e77", "#d95f02", "#7570b3")
+```
+
+---
+
+## Data Prep Pipeline
+
+```r
+# 1_prep_data.R
+source("0_setup_plots.R")
+
+df <- read_csv("../data/input/trade.csv") %>%
+  mutate(real_exports = exports / cpi)
+
+write_csv(df, "../data/intermediate_datasets/trade_clean.csv")
+```
+
+---
+
+## Multi-Panel Figure
+
+```r
+# 2_make_figure.R
+source("0_setup_plots.R")
+
+df <- read_csv("../data/intermediate_datasets/trade_clean.csv")
+
+p1 <- df %>%
+  ggplot(aes(year, real_exports, color = country)) +
+  geom_line(size = 1) +
+  scale_color_manual(values = default_colors) +
+  labs(x = NULL, y = "Real Exports", title = "Exports over Time")
+
+p2 <- df %>%
+  ggplot(aes(real_exports, gdp_growth, color = country)) +
+  geom_point() +
+  scale_color_manual(values = default_colors) +
+  labs(x = "Real Exports", y = "GDP Growth")
+
+library(patchwork)
+figure <- p1 / p2 + plot_layout(guides = 'collect')
+
+# Export
+fig_path <- "../output/figures/exports_figure.pdf"
+ggsave(fig_path, figure, width = 6, height = 8)
+```
+
+---
+
+## Metadata
+
+Alongside every exported figure, create a `.yml` file with metadata:
+
+```yaml
+# exports_figure.yml
+figure: exports_figure.pdf
+description: "Relationship between real exports and GDP growth"
+author: Jane Doe
+date: 2024-05-15
+version: v01
+input_data: trade_clean.csv
+```
+
+---
+
+☑️ Track figures and metadata in `output/figures/` and rerun scripts via `source("2_make_figure.R")`. Ensure your environment is clean (no leftover objects) before generating figures.

--- a/templates/shell_replication_template.md
+++ b/templates/shell_replication_template.md
@@ -1,0 +1,81 @@
+# Shell Script Template – Replication Package
+
+The script below bundles code, data, and output into a timestamped zip file while recording every action in a log. Adapt paths and commands to fit your project.
+
+---
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+#-------------------------------------------#
+# Configuration
+#-------------------------------------------#
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PACKAGE_DIR="$PROJECT_ROOT/replication_package"
+LOG_FILE="$PROJECT_ROOT/output/logs/replicate_$(date +%Y%m%d_%H%M%S).log"
+ZIP_FILE="$PROJECT_ROOT/output/replication_$(date +%Y%m%d).zip"
+
+log() {
+  local ts=$(date '+%Y-%m-%d %H:%M:%S')
+  echo "[$ts] $1" | tee -a "$LOG_FILE"
+}
+
+hash_file() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+main() {
+  log "Creating replication package."
+
+  # 1. Clean previous package
+  rm -rf "$PACKAGE_DIR"
+  mkdir -p "$PACKAGE_DIR"/{{code,data,output}}
+
+  # 2. Copy essential files (editlists as needed)
+  log "Copying code, data, and output."
+  rsync -av --exclude='*.log' "$PROJECT_ROOT/code/" "$PACKAGE_DIR/code/" | tee -a "$LOG_FILE"
+  rsync -av "$PROJECT_ROOT/data/input/" "$PACKAGE_DIR/data/input/" | tee -a "$LOG_FILE"
+  rsync -av "$PROJECT_ROOT/output/figures/" "$PACKAGE_DIR/output/figures/" | tee -a "$LOG_FILE"
+
+  # 3. Generate manifest with checksums
+  log "Generating manifest.json."
+  {
+    echo "{\n  \"files\": ["
+    find "$PACKAGE_DIR" -type f | while read -r file; do
+      checksum=$(hash_file "$file")
+      rel_path="${file#$PACKAGE_DIR/}"
+      echo "    {\"path\": \"$rel_path\", \"sha256\": \"$checksum\"},"
+    done
+    echo "  ]\n}"
+  } > "$PACKAGE_DIR/manifest.json"
+
+  # 4. Zip the package
+  log "Compressing package to $ZIP_FILE."
+  (cd "$PACKAGE_DIR/.." && zip -r "$ZIP_FILE" "$(basename "$PACKAGE_DIR")") | tee -a "$LOG_FILE"
+
+  log "Replication package created successfully."
+}
+
+main "$@"
+```
+
+---
+
+## How to Use
+
+1. Save the script as `create_replication_package.sh` in `templates/`.
+2. Make it executable: `chmod +x create_replication_package.sh`.
+3. Run from project root: `./templates/create_replication_package.sh`.
+4. Verify the ZIP in `output/` and share it alongside your paper.
+
+---
+
+## Checklist Embedded in Script
+
+- [x] Create fresh directory structure
+- [x] Copy only required files
+- [x] Generate checksums for integrity
+- [x] Log every step
+- [x] Compress into portable archive

--- a/templates/stata_analysis_template.md
+++ b/templates/stata_analysis_template.md
@@ -1,0 +1,77 @@
+# Stata Analysis Template
+
+Use this modular framework to organize Stata code for a typical empirical paper. Each program performs a focused task and writes outputs for post-processing.
+
+---
+
+## Project Skeleton
+
+```text
+code/
+├── 0_setup.do
+├── 1_clean_data.do
+├── 2_generate_vars.do
+├── 3_regressions.do
+├── 4_export_output.do
+└── master.do
+```
+
+---
+
+## 0_setup.do
+
+```stata
+*------------------------------------------------------------------------------*
+* 0_setup.do - Install packages, set globals, and initialize log              *
+*------------------------------------------------------------------------------*
+clear all
+set more off
+
+* Paths
+if ("`c(os)'" == "Windows") global projdir "C:/Projects/myproject" // adjust
+else                        global projdir "~/myproject"
+
+global codedir  "$projdir/code"
+set linesize 80
+
+* Install required packages
+ssc install estout, replace
+ssc install reghdfe, replace
+```
+
+---
+
+## 1_clean_data.do
+
+```stata
+* Clean raw data and save to intermediate_datasets
+use "$projdir/data/input/raw_survey.dta", clear
+
+* Variable renaming
+rename (income wage) (household_income hourly_wage)
+
+* Keep complete cases
+keep if !missing(household_income, hourly_wage)
+
+save "$projdir/data/intermediate_datasets/survey_clean.dta", replace
+```
+
+---
+
+## 3_regressions.do (Excerpt)
+
+```stata
+capture program drop run_regs
+program define run_regs
+    syntax , OUTFILE(string)
+
+    reghdfe hourly_wage household_income age i.year, absorb(industry) vce(cluster id)
+    esttab using "`outfile'", replace se star(* 0.10 ** 0.05 *** 0.01)
+end
+
+run_regs , outfile("$projdir/output/tables/wage_regs.tex")
+```
+
+---
+
+☑️ Combine everything in `master.do` as shown in the [Stata Guide](../languages/stata.md#⚙️-example-masterdo).

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,129 @@
+# Workflows & Project Automation
+
+This section shows how to glue together scripts, manage dependencies, and deliver fully reproducible research outputs.
+
+---
+
+## 🌀 Master Script Patterns (All Languages)
+
+1. **Setup** – Install packages, set global paths.
+2. **Data Prep** – Clean raw data into analytical datasets.
+3. **Analysis** – Run models, simulations, or estimations.
+4. **Output** – Export tables, figures, and logs.
+5. **Session Info** – Record language version and package list.
+
+Your master script (e.g., `master.do`, `run_all.R`, or `main.py`) should execute all the above steps **with a single command**.
+
+---
+
+## 📦 Dependency Management
+
+| Language | Tool | How to Lock |
+|----------|------|-------------|
+| Stata | `ssctype pkg` | Document package versions in `docs/dependencies.md` |
+| R | `renv` | Commit `renv.lock` |
+| Python | `pip` + `requirements.txt` or `pipenv` | Pin versions and commit lockfile |
+| Shell | System packages | Use `apt-get install` lines in setup script |
+
+---
+
+## 🔁 Automated Testing Approaches
+
+- **Stata** – Use [`stataunit`](https://github.com/limoood/stataunit) for program tests.
+- **R** – `testthat::test_dir("tests")` integrated with `devtools::check()`.
+- **Python** – `pytest` with GitHub Actions.
+
+See template CI workflows in `.github/workflows/` (coming soon).
+
+---
+
+## 💾 Creating Replication Packages with Shell Scripts
+
+1. Run analysis and confirm logs are clean.
+2. Collect *only* necessary data, scripts, and output.
+3. Hash each file and generate a `manifest.json` for integrity.
+4. Zip the package and test extraction in a clean environment.
+
+See [shell replication template](../templates/shell_replication_template.md) for an example implementation.
+
+---
+
+## 🖥️ Documentation of Computational Environment
+
+Always capture:
+
+- OS and version (e.g., `uname -a`)
+- Language interpreter versions (`stata -q`, `R --version`, `python --version`)
+- Package versions (`ssc desc`, `renv::snapshot()`, `pip freeze`)
+
+Include the output in `output/logs/session_info.txt`.
+
+---
+
+## 🐙 GitHub Essentials for Social Scientists
+
+### Setup
+
+1. Create a GitHub account and install Git.
+2. Configure user details:
+   ```bash
+   git config --global user.name "Jane Doe"
+   git config --global user.email "jane@uni.edu"
+   ```
+3. Generate an SSH key and add to GitHub.
+
+### Basic Workflow
+
+```bash
+git clone <repo-url>
+# work, work, work
+git add file.R
+git commit -m "Add data cleaning script"
+git push origin main
+git pull
+```
+
+### `.gitignore` Templates
+
+```gitignore
+# Stata
+*.log
+*.smcl
+
+# R
+.Rhistory
+.RData
+.Rproj.user
+
+# Python
+__pycache__/
+*.pyc
+venv/
+
+# General
+.DS_Store
+*.tmp
+```
+
+Copy & paste the lines relevant to your project in the root `.gitignore`.
+
+### Commit Messages
+
+- Use **present tense**: "Add regression table".
+- Limit to **50 characters**.
+- Reference issues, e.g., `Fix wage variable (#12)`.
+
+### Repository Structure for Replication
+
+```
+replication_package/
+├── code/
+├── data/
+├── output/
+├── README.md
+└── LICENSE
+```
+
+---
+
+Proceed to the [Templates](../templates/README.md) section to bootstrap your own scripts.


### PR DESCRIPTION
Initial commit of the Empirical Economics Lab Manual to provide comprehensive guidance on reproducible research and coding standards for research assistants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Completely rewrote and generalized the main README for broader use in empirical economics labs, adding a modern table of contents, simplified quick start, and clear contributing and license sections.
  * Added a comprehensive best practices checklist covering all research stages.
  * Introduced foundational guidelines for reproducible research, including coding, data management, version control, and documentation standards.
  * Created language-specific guides for Python, R, Stata, and Shell, each with detailed style conventions, best practices, and workflow templates.
  * Added workflow documentation covering master scripts, dependency management, automated testing, replication packaging, and GitHub usage.
  * Introduced templates for Shell replication, Stata analysis, and R visualization, each with step-by-step examples and metadata tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->